### PR TITLE
Merge clean_unused_channels_change

### DIFF
--- a/shirt_bot.py
+++ b/shirt_bot.py
@@ -782,13 +782,12 @@ async def error__links_toggle(ctx, error):
 # #######################
 
 
-clean_unused_channels.start()
+update_data_files.start()
 loop = asyncio.get_event_loop()
 try:
     loop.run_until_complete(bot.start(TOKEN))
 except KeyboardInterrupt:
     loop.run_until_complete(bot.close())
     update_data_files.stop()
-    clean_unused_channels.stop()
 finally:
     discord.client._cleanup_loop(loop)


### PR DESCRIPTION
Made cleanup_unused_channels a coroutine.
cleanup_unused_channels used to be a task, but I suspect it may have
caused issues with data writes sometimes getting stuck. It is now a
coroutine that runs inside of the update_data_channels task.